### PR TITLE
chore: add workflow definition to deploy GitHub pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,78 @@
+name: deploy-to-github-pages
+
+permissions:
+  contents: read
+  actions: read
+  pages: write
+  id-token: write
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - gh-pages
+
+concurrency:
+  group: ${{ github.workflow }}-gh-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DOCKER_COMPOSE_DIRECTORY: environments/ci
+
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Check version info
+        run: pwd && docker compose version && docker --version
+
+      - name: Get UID/GID of the runner
+        id: get_uid_gid
+        run: |
+          echo "HOST_UID=$(id -u)" >> $GITHUB_ENV
+          echo "HOST_GID=$(id -g)" >> $GITHUB_ENV
+
+      - name: Create and start docker container
+        run: docker compose up -d
+        working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
+
+      - name: Run lint
+        run: docker compose exec -T frontend yarn lint
+        working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
+
+      - name: Build
+        run: docker compose exec -T frontend yarn build
+        working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
+
+      - name: Stop container
+        if: always()
+        run: docker compose down
+        working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: github-pages
+          path: ./build/client
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

This PR updates the GitHub Pages deployment workflow to build and deploy from the `gh-pages` branch instead of the default branch.

## Changes

* Trigger the workflow on:

  * `push` events to the `gh-pages` branch
  * manual execution via `workflow_dispatch`
* Explicitly checkout the `gh-pages` branch in the build job
* Scope concurrency to `gh-pages` deployments to avoid conflicts
* Keep the existing Docker-based build, lint, and deploy steps unchanged

## Motivation

We want to deploy site assets directly from the `gh-pages` branch.

## Testing

* [ ] Push to `gh-pages` triggers the workflow
* [ ] Deployment completes successfully
* [ ] The published site reflects the updated content from `gh-pages`